### PR TITLE
因小程序canvas无法接受bind:绑定事件 修改v-on的parseHandler

### DIFF
--- a/packages/cli/core/plugins/template/directives/v-on.js
+++ b/packages/cli/core/plugins/template/directives/v-on.js
@@ -110,7 +110,11 @@ const parseHandler = (name = '', value = '', scope) => {
   info = parseHandlerProxy(value, scope);
 
   if (name === 'click') name = 'tap';
-  type = 'bind:' + name;
+  if (name.startsWith("touch")) {
+    type = 'bind' + name;
+  } else {
+    type = 'bind:' + name;
+  }
   return {
     event: name,
     type: type,


### PR DESCRIPTION
因小程序canvas无法接受bind:绑定事件 修改v-on的parseHandler 在touch相关事件使用bindtouch***

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm run test` passes
- [ ] tests and/or benchmarks are included
- [ ] cases or donate is changed or added
- [ ] documentation is changed or added
